### PR TITLE
Make launchpads KCT-friendly

### DIFF
--- a/GameData/KatnisssCapeCanaveral/instances/kLC39-instances.cfg
+++ b/GameData/KatnisssCapeCanaveral/instances/kLC39-instances.cfg
@@ -21,9 +21,9 @@ STATIC
 			CloseValue = 0
 			FacilityName = 
 			LaunchPadTransform = _launchpad
-			LaunchSiteName = LC 39B
+			LaunchSiteName = LC-39B
 			LaunchSiteAuthor = Katniss
-			LaunchSiteType = Any
+			LaunchSiteType = VAB
 			LaunchSiteDescription = Do not expose to sunlight, water, air, or space.
 			LaunchSiteLength = 99
 			LaunchSiteWidth = 99
@@ -33,9 +33,9 @@ STATIC
 			InitialCameraRotation = 90
 			ILSIsActive = False
 			ToggleLaunchPositioning = False
-			OpenCloseState = Closed
+			OpenCloseState = Open
 			LaunchSiteIsHidden = False
-			Category = Other
+			Category = RocketPad
 		}
 	}
 	Instances
@@ -58,7 +58,7 @@ STATIC
 			LaunchPadTransform = _launchpad
 			LaunchSiteName = LC-39A
 			LaunchSiteAuthor = Katniss
-			LaunchSiteType = Any
+			LaunchSiteType = VAB
 			LaunchSiteDescription = Do not expose to sunlight, water, air, or space.
 			LaunchSiteLength = 99
 			LaunchSiteWidth = 99
@@ -68,9 +68,9 @@ STATIC
 			InitialCameraRotation = 90
 			ILSIsActive = False
 			ToggleLaunchPositioning = False
-			OpenCloseState = Closed
+			OpenCloseState = Open
 			LaunchSiteIsHidden = False
-			Category = Other
+			Category = RocketPad
 		}
 	}
 }


### PR DESCRIPTION
Give the launchpads LaunchSiteType = VAB, Category = RocketPad, OpenCloseState = Open.
Without these changes, the pads randomly end up in KCT's list of runways instead of its list of launchpads. Not positive which changes are actually needed, but with all 3, things seem to work reliably.

Also here: use consistent naming convention for the 2 pads